### PR TITLE
Fix: Correct HTML escaping to prevent XSS

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -871,8 +871,8 @@ function escapeHtml(text) {
     if (!text) return '';
     return text.toString()
         .replace(/&/g, '&amp;')
-        .replace(/</g, '<')
-        .replace(/>/g, '>')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#039;');
 }


### PR DESCRIPTION
Quick experiment with Google Jules to see how efficiently and effectively it does code review: 

The `escapeHtml` function in `js/main.js` was not correctly escaping the `<` and `>` characters, which could lead to a cross-site scripting (XSS) vulnerability. This commit corrects the function to properly replace these characters with their corresponding HTML entities, `&lt;` and `&gt;`.